### PR TITLE
Add stargate and bookmaker

### DIFF
--- a/provider/incompatible_sites.json
+++ b/provider/incompatible_sites.json
@@ -31,5 +31,7 @@
     "zk.money",
     "manifold.xyz",
     "orionprotocol.io",
-    "portal.zksync.io"
+    "portal.zksync.io",
+    "stargate.finance",
+    "bookmaker.xyz"
 ]


### PR DESCRIPTION
This PR adds the following domains to the incompatible sites list: 
- stargate.finance
- bookmaker.xyz