### PR TITLE
Add incompatible sites

### DIFF
--- a/provider/incompatible_sites.json
+++ b/provider/incompatible_sites.json
@@ -26,5 +26,7 @@
     "portal.zksync.io",
     "stargate.finance",
     "bookmaker.xyz",
-    "labs.zetachain.com"
+    "labs.zetachain.com",
+    "app.buffer.finance",
+    "staking.chain.link"
 ]


### PR DESCRIPTION
This PR adds the following apps to the list of sites:
- https://staking.chain.link/
- https://app.buffer.finance/